### PR TITLE
fix(events): fix migrations to not use django-extensions.

### DIFF
--- a/fossevents/events/migrations/0001_initial.py
+++ b/fossevents/events/migrations/0001_initial.py
@@ -3,7 +3,6 @@
 
 from django.db import models, migrations
 import django.utils.timezone
-import django_extensions.db.fields
 import uuid
 
 
@@ -16,8 +15,8 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Event',
             fields=[
-                ('created', django_extensions.db.fields.CreationDateTimeField(default=django.utils.timezone.now, verbose_name='created', editable=False, blank=True)),
-                ('modified', django_extensions.db.fields.ModificationDateTimeField(default=django.utils.timezone.now, verbose_name='modified', editable=False, blank=True)),
+                ('created', models.DateTimeField(auto_now_add=True, editable=False)),
+                ('modified', models.DateTimeField(auto_now=True, editable=False)),
                 ('id', models.UUIDField(default=uuid.uuid4, serialize=False, editable=False, primary_key=True)),
                 ('name', models.CharField(max_length=100, verbose_name='name')),
                 ('description', models.TextField(verbose_name='description')),

--- a/fossevents/events/migrations/0002_auto_20150925_1127.py
+++ b/fossevents/events/migrations/0002_auto_20150925_1127.py
@@ -3,7 +3,6 @@
 
 from django.db import models, migrations
 import django_markdown.models
-import django_extensions.db.fields
 
 
 class Migration(migrations.Migration):
@@ -16,7 +15,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='event',
             name='created',
-            field=django_extensions.db.fields.CreationDateTimeField(auto_now_add=True, verbose_name='created'),
+            field=models.DateTimeField(auto_now_add=True, verbose_name='created'),
         ),
         migrations.AlterField(
             model_name='event',
@@ -26,7 +25,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='event',
             name='modified',
-            field=django_extensions.db.fields.ModificationDateTimeField(auto_now=True, verbose_name='modified'),
+            field=models.DateTimeField(auto_now=True, verbose_name='modified'),
         ),
         migrations.AlterField(
             model_name='event',

--- a/settings/common.py
+++ b/settings/common.py
@@ -13,6 +13,7 @@ env = environ.Env()
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#admins
 ADMINS = (
     ('Saurabh Kumar', 'saurabh+fossevents@saurabh-kumar.com'),
+    ('Mayank Jain', 'jainmickey93+fossevents@gmail.com'),
 )
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#managers


### PR DESCRIPTION
- Remove `django-extensions` dependency from migrations.
- Add myself to admin lists.
