### PR TITLE
Fix datetime popup

### DIFF
--- a/fossevents/events/forms.py
+++ b/fossevents/events/forms.py
@@ -7,14 +7,14 @@ class EventForm(forms.ModelForm):
     description = forms.CharField(widget=forms.Textarea(attrs={'placeholder': 'Enter description...'},),
                                   help_text='<a href="https://guides.github.com/features/mastering-markdown/">'
                                             'Markdown supported</a>')
-    start_date = forms.DateTimeField(input_formats=["%Y-%m-%d", "%Y-%m-%dT%H:%M"],
-                                     widget=forms.DateTimeInput(attrs={'placeholder': 'YYYY-MM-DDTHH:MM',
-                                                                       'type': 'datetime-local'},
-                                                                format='%Y-%m-%dT%H:%M'))
-    end_date = forms.DateTimeField(input_formats=["%Y-%m-%d", "%Y-%m-%dT%H:%M"],
-                                   widget=forms.DateTimeInput(attrs={'placeholder': 'YYYY-MM-DDTHH:MM',
-                                                                     'type': 'datetime-local'},
-                                                              format='%Y-%m-%dT%H:%M'))
+    start_date = forms.DateTimeField(input_formats=["%Y-%m-%d", "%Y-%m-%d %H:%M"],
+                                     widget=forms.DateTimeInput(attrs={'placeholder': 'YYYY-MM-DD HH:MM',
+                                                                       'type': 'datetime'},
+                                                                format='%Y-%m-%d %H:%M'))
+    end_date = forms.DateTimeField(input_formats=["%Y-%m-%d", "%Y-%m-%d %H:%M"],
+                                   widget=forms.DateTimeInput(attrs={'placeholder': 'YYYY-MM-DD HH:MM',
+                                                                     'type': 'datetime'},
+                                                              format='%Y-%m-%d %H:%M'))
 
     class Meta:
         model = Event

--- a/fossevents/events/forms.py
+++ b/fossevents/events/forms.py
@@ -15,13 +15,13 @@ class EventForm(forms.ModelForm):
                                    widget=forms.DateTimeInput(attrs={'placeholder': 'YYYY-MM-DD HH:MM',
                                                                      'type': 'datetime'},
                                                               format='%Y-%m-%d %H:%M'))
+    homepage = forms.URLField(widget=forms.URLInput(attrs={'placeholder': 'http://example.com', 'type': 'text'}))
 
     class Meta:
         model = Event
         exclude = ('auth_token', 'is_published')
         widgets = {
             'name': forms.TextInput(attrs={'placeholder': 'Title'}),
-            'homepage': forms.URLInput(attrs={'placeholder': 'http://example.com'}),
             'owner_email': forms.EmailInput(attrs={'placeholder': 'user@example.com'}),
         }
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -5,7 +5,6 @@ import datetime
 
 # Third Party Stuff
 import factory
-from factory import fuzzy
 from django.conf import settings
 from django.utils import lorem_ipsum
 
@@ -46,8 +45,8 @@ class EventFactory(Factory):
         strategy = factory.CREATE_STRATEGY
 
     name = factory.Sequence(lambda n: "fossevent{}".format(n))
-    start_date = fuzzy.FuzzyDate(datetime.date.today(), datetime.date(2017, 1, 1)).fuzz()
-    end_date = start_date + datetime.timedelta(3)
+    start_date = datetime.date.today()
+    end_date = start_date + datetime.timedelta(days=3)
     description = lorem_ipsum.paragraph()
     # logo
     # status = factory.Iterator(dict(CONFERENCE_STATUS_LIST).keys())

--- a/tests/integrations/test_events_views.py
+++ b/tests/integrations/test_events_views.py
@@ -40,6 +40,22 @@ def test_event_create(client, mocker):
     assert response.status_code == 302
 
 
+def test_event_create_without_url_scheme(client, mocker):
+    url = reverse('event-create')
+
+    data = {
+        'name': 'Event01',
+        'description': 'Event01 description',
+        'start_date': '2016-08-12 21:00',
+        'end_date': '2016-08-13 18:00',
+        'homepage': 'example.com',
+        'owner_email': 'test@example.com'
+    }
+
+    response = client.post(url, data)
+    assert response.status_code == 302
+
+
 EventErrorCasesData = [
     ({}, 'name'),
     ({
@@ -105,6 +121,15 @@ EventErrorCasesData = [
          'homepage': 'http://example.com',
          'owner_email': 'test@example.com'
      }, 'end_date'),
+    ({
+         # Invalid url
+         'name': 'Event01',
+         'description': 'Event01 description',
+         'start_date': '2016-08-12',
+         'end_date': '2016-08-11',
+         'homepage': 'example',
+         'owner_email': 'test@example.com'
+     }, 'homepage'),
     ({
         # Owner email required field
         'name': 'Event01',


### PR DESCRIPTION
- Remove date time popup as it was confusing and does not work on firefox.
- Allow without scheme URL in `homepage` field.